### PR TITLE
Ensure generate_random_value reports success

### DIFF
--- a/libraries/atecc/src/atecc_cmd.c
+++ b/libraries/atecc/src/atecc_cmd.c
@@ -119,6 +119,7 @@ bool generate_random_value(uint8_t length) {
         printf("%02X ", response[i]);
         if ((i + 1) % 16 == 0) printf("\n");
     }
+    return true;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Ensure `generate_random_value` returns `true` when random bytes are printed
- Keep existing error checks returning `false`

## Testing
- `cmake -S . -B build` *(fails: pico-sdk/pico_sdk_init.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d47efd940832299e5683dbc32834f