### PR TITLE
Add Pico SDK installation script for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,13 @@ This project is designed to interface the Microchip ATECC608A Cryptographic Co-p
    configure the Pico SDK automatically, which is useful in testing
    environments.
 
-3. Build the project:
+3. Install the GNU Arm toolchain:
+    ```sh
+    sudo apt-get update
+    sudo apt-get install -y gcc-arm-none-eabi
+    ```
+
+4. Build the project:
     ```sh
     mkdir build
     cd build
@@ -66,7 +72,7 @@ This project is designed to interface the Microchip ATECC608A Cryptographic Co-p
     cmake -DPICO_BOARD=pico2 ..
     ```
 
-4. Flash the firmware onto the Pico:
+5. Flash the firmware onto the Pico:
     - Hold the BOOTSEL button on the Pico and connect it to your PC.
     - Copy the generated `pico_atecc.uf2` file to the `RPI-RP2` USB drive.
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ This project is designed to interface the Microchip ATECC608A Cryptographic Co-p
     ```sh
     git submodule update --init --recursive
     ```
+   The script `scripts/install-pico-sdk.sh` can also be used to fetch and
+   configure the Pico SDK automatically, which is useful in testing
+   environments.
 
 3. Build the project:
     ```sh

--- a/scripts/install-pico-sdk.sh
+++ b/scripts/install-pico-sdk.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Install and configure the Pico SDK for tests or builds.
+# Fetches the submodule if it isn't already present and
+# exports PICO_SDK_PATH for the current shell.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Initialize the Pico SDK submodule if necessary
+if [ ! -d "${REPO_ROOT}/pico-sdk/.git" ]; then
+    git -C "${REPO_ROOT}" submodule update --init --recursive pico-sdk
+fi
+
+export PICO_SDK_PATH="${REPO_ROOT}/pico-sdk"
+echo "PICO_SDK_PATH set to ${PICO_SDK_PATH}"


### PR DESCRIPTION
## Summary
- add script to fetch pico-sdk submodule and export PICO_SDK_PATH
- document new install script in README for testing environments

## Testing
- `./scripts/install-pico-sdk.sh`
- `mkdir -p build && cd build && cmake ..` *(fails: Compiler 'arm-none-eabi-gcc' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ecaa4af508322a61c938d8312ce02